### PR TITLE
Remove `init-package-json` library

### DIFF
--- a/git/git-ui/git-ui.js
+++ b/git/git-ui/git-ui.js
@@ -1,6 +1,6 @@
 const git = require('simple-git')();
 const fs = require('fs');
-const init = require('init-package-json');
+const exec = require('child_process').exec;
 
 const remote = 'origin';
 const branch = 'staging';
@@ -13,9 +13,11 @@ module.exports = {
         reject(err);
       } else {
         // generates a new package.json based on node_modules
-        init(userDir, userDir, { yes: 'yes' }, (er) => {
+        exec('npm init -y', { cwd: userDir }, (er, stdout, stderr) => {
           if (er) {
             reject(er);
+          } else if (stderr) {
+            reject(stderr);
           } else {
             // commits and pushes all changes to the remote branch
             git.add('--all').commit(message).push(remote, branch, (ex, data) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,22 +86,20 @@
         "balanced-match": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "dev": true
         },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-        },
-        "builtins": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-            "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
         },
         "caller-path": {
             "version": "0.1.0",
@@ -154,7 +152,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.6.0",
@@ -398,7 +397,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "function-bind": {
             "version": "1.1.0",
@@ -421,7 +421,8 @@
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true
         },
         "globals": {
             "version": "9.18.0",
@@ -438,7 +439,8 @@
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
         },
         "has": {
             "version": "1.0.1",
@@ -455,7 +457,8 @@
         "hosted-git-info": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+            "dev": true
         },
         "i18next-client": {
             "version": "1.10.3",
@@ -477,17 +480,14 @@
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
         },
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "init-package-json": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
-            "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o="
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
         },
         "inquirer": {
             "version": "0.12.0",
@@ -510,7 +510,8 @@
         "is-builtin-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
@@ -560,11 +561,6 @@
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
-        "jju": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-            "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
-        },
         "js-tokens": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
@@ -576,11 +572,6 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
             "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
             "dev": true
-        },
-        "json-parse-helpfulerror": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-            "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w="
         },
         "json-stable-stringify": {
             "version": "1.0.1",
@@ -641,7 +632,8 @@
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
         },
         "minimist": {
             "version": "0.0.8",
@@ -663,7 +655,8 @@
         "mute-stream": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -674,12 +667,8 @@
         "normalize-package-data": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
-        },
-        "npm-package-arg": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-            "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA=="
+            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+            "dev": true
         },
         "number-is-nan": {
             "version": "1.0.1",
@@ -696,7 +685,8 @@
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
         },
         "onetime": {
             "version": "1.1.0",
@@ -713,17 +703,8 @@
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-        },
-        "osenv": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-            "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
         },
         "p-limit": {
             "version": "1.1.0",
@@ -752,7 +733,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -819,21 +801,6 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
             "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
             "dev": true
-        },
-        "promzard": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-            "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4="
-        },
-        "read": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
-        },
-        "read-package-json": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
-            "integrity": "sha1-+Tpk5kFSnfaKCMZN5GOJ6KP4iEU="
         },
         "read-pkg": {
             "version": "2.0.0",
@@ -924,7 +891,8 @@
         "semver": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
         },
         "shelljs": {
             "version": "0.7.8",
@@ -946,17 +914,20 @@
         "spdx-correct": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "dev": true
         },
         "spdx-expression-parse": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+            "dev": true
         },
         "spdx-license-ids": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -1065,12 +1036,8 @@
         "validate-npm-package-license": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
-        },
-        "validate-npm-package-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-            "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34="
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "dev": true
         },
         "wordwrap": {
             "version": "1.0.0",
@@ -1081,7 +1048,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write": {
             "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-git-ui",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "lockfileVersion": 1,
     "dependencies": {
         "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-git-ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "i18next-client": "1.10.3",
-    "init-package-json": "^1.10.1",
     "simple-git": "1.73.0"
   }
 }


### PR DESCRIPTION
The `init-package-json` library required a npm < 4. Yet, the docker running the node-red has got npm 3.10.10. That's why it should be removed.