### PR TITLE
Fix npm init throwing stderr with a success message

### DIFF
--- a/git/git-ui/git-ui.js
+++ b/git/git-ui/git-ui.js
@@ -5,6 +5,7 @@ const exec = require('child_process').exec;
 const remote = 'origin';
 const branch = 'staging';
 const fileDoesNotExist = 'ENOENT';
+const successInitMessage = 'init written successfully';
 
 module.exports = {
   commit: (userDir, message) => new Promise((resolve, reject) => {
@@ -14,10 +15,10 @@ module.exports = {
         reject(err);
       } else {
         // generates a new package.json based on node_modules
-        exec('npm init -y', { cwd: userDir }, (er, stdout, stderr) => {
-          if (er) {
-            reject(er);
-          } else if (stderr) {
+        exec('npm init -y', { cwd: userDir }, (error, stdout, stderr) => {
+          if (error) {
+            reject(error);
+          } else if (stderr && !stderr.includes(successInitMessage)) {
             reject(stderr);
           } else {
             // commits and pushes all changes to the remote branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-git-ui",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "lockfileVersion": 1,
     "dependencies": {
         "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-git-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When executing `npm init -y`, it might send a success message as stderr. This is not an error and the message shall be ignored.